### PR TITLE
Feature/versioning serializer transform base check

### DIFF
--- a/drf_versioning/exceptions.py
+++ b/drf_versioning/exceptions.py
@@ -4,3 +4,7 @@ class VersionDoesNotExist(Exception):
 
 class TransformsNotDeclaredException(Exception):
     pass
+
+
+class TransformBaseNotDeclaredException(Exception):
+    pass

--- a/drf_versioning/transform/serializers.py
+++ b/drf_versioning/transform/serializers.py
@@ -5,7 +5,7 @@ from django.http import QueryDict
 from rest_framework import serializers
 
 from . import Transform
-from ..exceptions import TransformsNotDeclaredException
+from ..exceptions import TransformsNotDeclaredException, TransformBaseNotDeclaredException
 from ..version import Version
 
 
@@ -21,15 +21,24 @@ def import_transforms(path: str) -> tuple[type[Transform]]:
 
 class VersioningSerializer(serializers.Serializer):
     transforms: tuple[type[Transform]] = None
+    transform_base: Version = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.check_transforms_declared()
+        self.check_transform_base_declared()
 
     def check_transforms_declared(self):
+        # TODO add type checking for transforms?
         if not self.transforms:
             raise TransformsNotDeclaredException(
                 f"{self.__class__.__name__} has not declared transforms."
+            )
+
+    def check_transform_base_declared(self):
+        if not self.transform_base:
+            raise TransformBaseNotDeclaredException(
+                f"{self.__class__.__name__} has not declared transform base."
             )
 
     def _get_request_version(self):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -7,7 +7,6 @@ from tests.models import Thing
 class ThingSerializer(VersioningSerializer, serializers.ModelSerializer):
     transforms = import_transforms("tests.transforms")
     # todo: now just get a metaclass to do this
-    # todo: metaclass to also check transform_base is declared
 
     class Meta:
         model = Thing

--- a/tests/tests/test_versioning_serializer.py
+++ b/tests/tests/test_versioning_serializer.py
@@ -1,6 +1,7 @@
 import pytest
 
-from drf_versioning.exceptions import TransformsNotDeclaredException
+from drf_versioning.exceptions import TransformsNotDeclaredException, TransformBaseNotDeclaredException
+from drf_versioning.transform import Transform
 from drf_versioning.transform.serializers import VersioningSerializer
 
 
@@ -11,3 +12,12 @@ def test_versioning_serializer_checks_for_transforms_at_instantiation():
     with pytest.raises(TransformsNotDeclaredException) as e:
         BadSerializer()
     assert str(e.value) == "BadSerializer has not declared transforms."
+
+
+def test_versioning_serializer_checks_for_transform_base_at_instantiation():
+    class BetterButBadSerializer(VersioningSerializer):
+        transforms = Transform()
+
+    with pytest.raises(TransformBaseNotDeclaredException) as e:
+        BetterButBadSerializer()
+    assert str(e.value) == "BetterButBadSerializer has not declared transform base."


### PR DESCRIPTION
Cleared out TODO mentioned in ThingSerializer. VersioningSerializer now checks for existence of transform_base. Please check if correct type was given.
Should the checks also do type checking?